### PR TITLE
Check for installed python modules using importlib.

### DIFF
--- a/service/common/generate_flatbuffers.py
+++ b/service/common/generate_flatbuffers.py
@@ -20,6 +20,7 @@ directory in the repository. If it must be regenerated, first remove the
 generated_flatbuffers directory, and run the code as normal, imported as a
 module in the code that needs the flatbuffers.
 """
+
 import glob
 import os
 import platform
@@ -29,6 +30,8 @@ import sys
 import tarfile
 import tempfile
 import urllib.request
+
+from common import pip_installer
 
 _FLATBUFFERS_DIR = 'generated_flatbuffers'
 
@@ -128,7 +131,9 @@ def generate():
   python file.
   """
   generated_fbs_dir = get_generated_flatbuffers_dir()
-  if not os.path.exists(generated_fbs_dir):
+
+  if not pip_installer.find_module_by_name('tflite.Model',
+                                           search_path=generated_fbs_dir):
     temp_dir = tempfile.mkdtemp()
     flatc = os.path.normpath(
         os.path.join(
@@ -151,6 +156,7 @@ def generate():
 
     shutil.rmtree(temp_dir)
     write_apache_license_header(generated_fbs_dir)
+    importlib.invalidate_caches()
 
   os.environ['FALKEN_GENERATED_FLATBUFFERS_DIR'] = (
       os.path.abspath(os.path.join(generated_fbs_dir, os.pardir)))

--- a/service/common/generate_protos.py
+++ b/service/common/generate_protos.py
@@ -14,14 +14,16 @@
 
 # Lint as: python3
 """Module to generate proto code for use by Falken service."""
+
 import glob
+import importlib
 import os
 import shutil
 import subprocess
 import sys
 import urllib.request
 
-import common.pip_installer  # pylint: disable=unused-import
+from common import pip_installer
 
 _PROTO_GEN_DIR = 'proto_gen_module'
 
@@ -91,7 +93,9 @@ def generate():
   directly import the protos.
   """
   generated_protos_dir = get_generated_protos_dir()
-  if not os.path.exists(generated_protos_dir):
+
+  if not pip_installer.find_module_by_name('falken_service_pb2_grpc',
+                                           search_path=generated_protos_dir):
     os.makedirs(generated_protos_dir)
     source_proto_dirs = get_source_proto_dirs()
     downloaded_proto_dir = download_external_protos()
@@ -108,6 +112,7 @@ def generate():
     except subprocess.CalledProcessError as error:
       clean_up()
       raise error
+    importlib.invalidate_caches()
   if generated_protos_dir not in sys.path:
     sys.path.append(generated_protos_dir)
   os.environ['FALKEN_GENERATED_PROTOS_DIR'] = (


### PR DESCRIPTION
pip list is slow, so instead try use importlib first to check for
the presence of a module. This is especially important when
multiple modules are installed as pip list was called again before
each pip module installation.