### PR TITLE
Fixed learner proto generation.

### DIFF
--- a/service/common/generate_flatbuffers.py
+++ b/service/common/generate_flatbuffers.py
@@ -134,6 +134,8 @@ def generate():
 
   if not pip_installer.find_module_by_name('tflite.Model',
                                            search_path=generated_fbs_dir):
+    if getattr(sys, 'frozen', False):
+      raise ModuleNotFoundError('FlatBuffers modules not frozen.')
     temp_dir = tempfile.mkdtemp()
     flatc = os.path.normpath(
         os.path.join(

--- a/service/common/generate_protos.py
+++ b/service/common/generate_protos.py
@@ -94,8 +94,10 @@ def generate():
   """
   generated_protos_dir = get_generated_protos_dir()
 
-  if not pip_installer.find_module_by_name('falken_service_pb2_grpc',
+  if not pip_installer.find_module_by_name('brain_pb2',
                                            search_path=generated_protos_dir):
+    if getattr(sys, 'frozen', False):
+      raise ModuleNotFoundError('Protocol Buffers modules not frozen.')
     os.makedirs(generated_protos_dir)
     source_proto_dirs = get_source_proto_dirs()
     downloaded_proto_dir = download_external_protos()

--- a/service/common/pip_installer.py
+++ b/service/common/pip_installer.py
@@ -131,7 +131,7 @@ def _module_installed(pip_module_name: str, import_module_name: str):
   if import_module_name and find_module_by_name(import_module_name):
     return True
   global _INSTALLED_MODULE_LIST
-  if not _INSTALLED_MODULE_LIST:
+  if not _INSTALLED_MODULE_LIST and not getattr(sys, 'frozen', False):
     logging.debug('Listing installed pip packages')
     result = subprocess.run([sys.executable, '-m', 'pip', 'list'],
                             stdout=subprocess.PIPE, check=True)
@@ -145,7 +145,7 @@ def _module_installed(pip_module_name: str, import_module_name: str):
 
 
 def _install_module(module: str, version: str):
-  """Install a Python module.
+  """Install a Python module if the application isn't frozen.
 
   Args:
     module: Name of the module to install.
@@ -155,8 +155,9 @@ def _install_module(module: str, version: str):
   Raises:
     subprocess.CalledProcessError: If module installation fails.
   """
-  logging.info('Installing Python module %s...', module)
-  subprocess.check_call(_PIP_INSTALL_ARGS + [f'{module}{version}'])
+  if not getattr(sys, 'frozen', False):
+    logging.info('Installing Python module %s...', module)
+    subprocess.check_call(_PIP_INSTALL_ARGS + [f'{module}{version}'])
 
 
 def _check_platform_constraints(module: str, constraints: PlatformConstraints):


### PR DESCRIPTION
The learner does not require the service proto which resulted
in proto generation executing when the application is frozen
since the service proto module isn't imported.

Also, this disables module installation, flatbuffer and
protocol buffer generation when using the service components
from a frozen module.